### PR TITLE
#281 Remove unnecessary senzingsdk-version matrix from test workflows

### DIFF
--- a/.github/workflows/go-test-darwin.yaml
+++ b/.github/workflows/go-test-darwin.yaml
@@ -38,23 +38,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run go test
-        env:
-          SENZING_SDK_VERSION: ${{ matrix.senzingsdk-version }}
         run: |
-          go test -json -v -p 1 -coverprofile="./cover-${SENZING_SDK_VERSION}.out" -covermode=atomic -coverpkg=./... ./...  2>&1 | tee "/tmp/gotest-${SENZING_SDK_VERSION}.log" | gotestfmt
+          go test -json -v -p 1 -coverprofile=./cover.out -covermode=atomic -coverpkg=./... ./...  2>&1 | tee /tmp/gotest.log | gotestfmt
 
       - name: Store coverage file
         uses: actions/upload-artifact@v6
         with:
-          name: "cover-${{ matrix.senzingsdk-version }}.out"
-          path: "./cover-${{ matrix.senzingsdk-version }}.out"
+          name: cover.out
+          path: ./cover.out
 
       - name: Upload test log
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: "test-log-${{ matrix.senzingsdk-version }}"
-          path: "/tmp/gotest-${{ matrix.senzingsdk-version }}.log"
+          name: test-log
+          path: /tmp/gotest.log
           if-no-files-found: error
 
   coverage:
@@ -65,4 +63,3 @@ jobs:
     uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
-      profile: "cover-production-v4.out,cover-staging-v4.out"

--- a/.github/workflows/go-test-darwin.yaml
+++ b/.github/workflows/go-test-darwin.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   go-test-darwin:
-    name: "Go test with Senzing: ${{ matrix.senzingsdk-version }}; OS: ${{ matrix.os }}; Go: ${{ matrix.go }}"
+    name: "Go test with OS: ${{ matrix.os }}; Go: ${{ matrix.go }}"
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -19,7 +19,6 @@ jobs:
       matrix:
         go: ["1.26"]
         os: [macos-latest]
-        senzingsdk-version: [staging-v4]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/go-test-linux.yaml
+++ b/.github/workflows/go-test-linux.yaml
@@ -38,23 +38,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run go test
-        env:
-          SENZING_SDK_VERSION: ${{ matrix.senzingsdk-version }}
         run: |
-          go test -json -v -p 1 -coverprofile="./cover-${SENZING_SDK_VERSION}.out" -covermode=atomic -coverpkg=./... ./...  2>&1 | tee "/tmp/gotest-${SENZING_SDK_VERSION}.log" | gotestfmt
+          go test -json -v -p 1 -coverprofile=./cover.out -covermode=atomic -coverpkg=./... ./...  2>&1 | tee /tmp/gotest.log | gotestfmt
 
       - name: Store coverage file
         uses: actions/upload-artifact@v6
         with:
-          name: "cover-${{ matrix.senzingsdk-version }}.out"
-          path: "./cover-${{ matrix.senzingsdk-version }}.out"
+          name: cover.out
+          path: ./cover.out
 
       - name: Upload test log
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: "test-log-${{ matrix.senzingsdk-version }}"
-          path: "/tmp/gotest-${{ matrix.senzingsdk-version }}.log"
+          name: test-log
+          path: /tmp/gotest.log
           if-no-files-found: error
 
   coverage:
@@ -65,7 +63,6 @@ jobs:
     uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
-      profile: "cover-production-v4.out,cover-staging-v4.out"
 
   slack-notification:
     needs: [go-test-linux]

--- a/.github/workflows/go-test-linux.yaml
+++ b/.github/workflows/go-test-linux.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   go-test-linux:
-    name: "Go test with Senzing: ${{ matrix.senzingsdk-version }}; OS: ${{ matrix.os }}; Go: ${{ matrix.go }}"
+    name: "Go test with OS: ${{ matrix.os }}; Go: ${{ matrix.go }}"
     outputs:
       status: ${{ job.status }}
     permissions:
@@ -21,7 +21,6 @@ jobs:
       matrix:
         go: ["1.26"]
         os: [ubuntu-latest]
-        senzingsdk-version: [staging-v4]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/go-test-windows.yaml
+++ b/.github/workflows/go-test-windows.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   go-test-windows:
-    name: "Go test with Senzing: ${{ matrix.senzingsdk-version }}; OS: windows-latest; Go: ${{ matrix.go }}"
+    name: "Go test with OS: windows-latest; Go: ${{ matrix.go }}"
     permissions:
       contents: read
     runs-on: windows-latest
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         go: ["1.26"]
-        senzingsdk-version: [staging-v4]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/go-test-windows.yaml
+++ b/.github/workflows/go-test-windows.yaml
@@ -37,24 +37,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run go test
-        env:
-          SENZING_SDK_VERSION: ${{ matrix.senzingsdk-version }}
         run: |
-          go test -json -v -p 1 -coverprofile=cover -covermode=atomic -coverpkg=./... ./... 2>&1 | tee "C:\Temp\gotest-$env:SENZING_SDK_VERSION.log" | gotestfmt
-          cp cover "cover-$env:SENZING_SDK_VERSION.out"
+          go test -json -v -p 1 -coverprofile=cover -covermode=atomic -coverpkg=./... ./... 2>&1 | tee "C:\Temp\gotest.log" | gotestfmt
+          cp cover cover.out
 
       - name: Store coverage file
         uses: actions/upload-artifact@v6
         with:
-          name: "cover-${{ matrix.senzingsdk-version }}.out"
-          path: "cover-${{ matrix.senzingsdk-version }}.out"
+          name: cover.out
+          path: cover.out
 
       - name: Upload test log
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: "test-log-${{ matrix.senzingsdk-version }}"
-          path: "C:\\Temp\\gotest-${{ matrix.senzingsdk-version }}.log"
+          name: test-log
+          path: "C:\\Temp\\gotest.log"
           if-no-files-found: error
 
   coverage:
@@ -65,4 +63,3 @@ jobs:
     uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
-      profile: "cover-production-v4.out,cover-staging-v4.out"


### PR DESCRIPTION
## Summary

- Remove unused `senzingsdk-version` matrix from test workflows that don't install the SDK
- Eliminates redundant CI runs (3x → 1x per platform)

Fixes #281

## Test plan

- [ ] Verify go-test workflows run once per platform instead of 3x

---

Resolves #281